### PR TITLE
Fix local build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,6 +2,7 @@
 REM NOTE: This file was auto-generated with `IB.exe prepare` from `IntelliFactory.Build`.
 
 setlocal
+set PATH=%PATH%;%ProgramFiles(x86)%\Microsoft SDKs\F#\4.0\Framework\v4.0
 set PATH=%PATH%;%ProgramFiles(x86)%\Microsoft SDKs\F#\3.1\Framework\v4.0
 set PATH=%PATH%;%ProgramFiles(x86)%\Microsoft SDKs\F#\3.0\Framework\v4.0
 set PATH=%PATH%;%ProgramFiles%\Microsoft SDKs\F#\3.1\Framework\v4.0


### PR DESCRIPTION
Beginning to try to fix the local build run by `build.cmd` for machines with only Visual Studio 2015 installed. I'll try to get it to actually build and then work on `build.sh`. The latter of these is the primary purpose for #2, though both are broken for me at present.
